### PR TITLE
Set permissions /bin/vendor to be root:www-data and 770

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY conf/msmtp /etc/msmtp.default
 
 # Conf files
 RUN touch /etc/msmtp /etc/osticket.secret.txt /etc/cron.d/osticket && \
-    chown www-data:www-data /etc/msmtp /etc/osticket.secret.txt /etc/cron.d/osticket
+    chown www-data:www-data /etc/msmtp /etc/osticket.secret.txt /etc/cron.d/osticket && \
+    chown root:www-data /bin/vendor && chmod 770 /bin/vendor
 
 VOLUME /var/www


### PR DESCRIPTION
This fixed issue: https://github.com/pi0/osticket-docker/issues/3. With this fix the webui runs and is reachable.