### PR TITLE
fix for current osTicket version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ COPY conf/msmtp /etc/msmtp.default
 # Conf files
 RUN touch /etc/msmtp /etc/osticket.secret.txt /etc/cron.d/osticket && \
     chown www-data:www-data /etc/msmtp /etc/osticket.secret.txt /etc/cron.d/osticket && \
-    chown root:www-data /bin/vendor && chmod 770 /bin/vendor
+    chown root:www-data /bin/vendor /bin/update && chmod 770 /bin/vendor /bin/update
 
 VOLUME /var/www

--- a/bin/osticket-install.php
+++ b/bin/osticket-install.php
@@ -4,11 +4,12 @@
 
 //Script settings
 
-define('INSTALL_DIR','/var/www/src/public');
-define('SETUP_DIR',INSTALL_DIR.'/../setup'); // use git setup
-define('INC_DIR',INSTALL_DIR.'/include');
-define('INSTALL_CONFIG',INC_DIR.'/ost-sampleconfig.php');
-define('OSTICKET_CONFIGFILE',INC_DIR.'/ost-config.php');
+define('INSTALL_DIR','/var/www/src/public/');
+define('SETUP_DIR',INSTALL_DIR.'../setup/'); // use git setup
+define('INC_DIR',SETUP_DIR.'inc/');
+define('INCLUDE_DIR',INSTALL_DIR.'include/');
+define('INSTALL_CONFIG',INCLUDE_DIR.'ost-sampleconfig.php');
+define('OSTICKET_CONFIGFILE',INCLUDE_DIR.'ost-config.php');
 
 define('MAIL_CONFIG','/etc/msmtp.default');
 define('MAIL_CONFIG_FILE','/etc/msmtp');
@@ -73,8 +74,8 @@ function convertStrToBool($varName, $default) {
 // Require files (must be done before any output to avoid session start warnings)
 // $_SERVER['HTTP_ACCEPT_LANGUAGE'] = LANGUAGE; 
 chdir(SETUP_DIR);
-require SETUP_DIR.'/setup.inc.php';
-require SETUP_DIR.'/inc/class.installer.php';
+require SETUP_DIR.'setup.inc.php';
+require SETUP_DIR.'inc/class.installer.php';
 
 /************************* Mail Configuration *******************************************/
 echo "Configuring mail settings\n";

--- a/bin/update
+++ b/bin/update
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+LOCK_FILE=/update.lock
+
+# Check if lock file exists
+if [ -f $LOCK_FILE ] ; then
+    # Check if really running
+    PID=`cat $LOCK_FILE`
+    if [ kill -s 0 $PID ] ; then
+        echo "$LOCK_FILE' with PID=$PID exists and running..."
+        exit 1
+    fi
+    echo "Warn: Cleaning stale lock file..."
+fi
+
+# Update lockfile with current PID
+echo $$ > $LOCK_FILE
+
+# Fix
+fix
+
+# Go to src
+cd /var/www/src
+
+# Git repo
+if [ ! -z $GIT_REPO ]; then
+  if [ -d .git ] ; then
+    run-as-www git pull
+  else
+    rmdir public
+    run-as-www git clone $GIT_REPO .
+  fi
+fi
+
+# Composer
+if [ -f composer.json ] ; then
+    run-as-www composer install --no-dev --no-interaction --no-progress --optimize-autoloader
+fi
+
+# .env
+if [ -f .env.example ] && [ ! -f .env ]; then
+    run-as-www cp -v .env.example .env
+fi
+
+# Laravel
+if [ -f artisan ] ; then
+    source .env
+    if [ -z $APP_KEY ]; then
+        run-as-www  php artisan key:generate
+    fi
+    run-as-www php artisan migrate || true
+fi
+
+# Yarn (do in background)
+if [ -f yarn.lock ] ; then
+    yarn-build &
+fi
+
+# User script
+if [ -x /bin/vendor ] ; then
+ run-as-www vendor
+fi
+
+# Remove lock file
+rm /update.lock

--- a/bin/vendor
+++ b/bin/vendor
@@ -2,7 +2,7 @@
 # Vendor script that runs on every container update event
 
 echo Deploying osTicket
-php /var/www/src/manage.php deploy -gsv /var/www/src/public || exit 1
+php /var/www/src/manage.php deploy -sfCgv /var/www/src/public || exit 1
 
 echo Install/Update osTicket
 php /bin/osticket-install.php || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,19 @@
-version: '2'
+version: '3'
 
 services:
 
   osticket:
+    build: .
     image: osticket/osticket
     environment:
       - MYSQL_HOST=mysql
       - MYSQL_DATABASE=osticket
       - MYSQL_USER=osticket
       - MYSQL_PASSWORD=0T1cket
-    
+
       # CHANGE ME
       - INSTALL_SECRET=secret
-        
+
       - LANGUAGE=fa
 
     links:


### PR DESCRIPTION
there were several broken thinks with the current version of osTicket eg. broken include dir paths and a renamed vendor script path by the upper docker image. i fixed those things so it works again. fixes #1 , related #6 