### PR TITLE
Update README.md, trailin slash to adminpanel

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ docker run --name osticket_mysql -d -e MYSQL_ROOT_PASSWORD=secret \
 docker run --name osticket -d --link osticket_mysql:mysql -p 8080:80 osticket/osticket
 ```
 
-Wait for the installation to complete then browse to your osTicket staff control panel at `http://localhost:8080/scp`. Login with default admin user & password:
+Wait for the installation to complete then browse to your osTicket staff control panel at `http://localhost:8080/scp/`*. Login with default admin user & password:
 
 * username: **ostadmin**
 * password: **Admin1**
 
 Now configure as required. If you are intending on using this image in production, please make sure you change the
 passwords above and read the rest of this documentation!
+
+(*) Without the trailing slash it will redirect to http://localhost/scp.
 
 # MySQL connection
 


### PR DESCRIPTION
Added a trailing slash to the admin link http://localhost:8080/scp/ to help first time users.